### PR TITLE
feat: add web search integration with DuckDuckGo to augment LLM respo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ A lightweight, modern LLM playground for testing prompts against OpenRouter-host
 - Tabbed result view with raw text (supporting JSON highlighting) and rendered Markdown outputs
 - Theme support (light/dark/system)
 - Docker containerized for easy deployment
+- **Web Search Integration:**
+  - Augments LLM responses with real-time information from the web.
+  - When enabled in Settings, the system:
+    1. Uses an ancillary LLM call to generate relevant search terms from your prompt.
+    2. Queries the DuckDuckGo search engine (via the `/api/search` backend route using the `@pikisoft/duckduckgo-search` package).
+    3. Injects the top search result snippets into the context for the main LLM, providing it with up-to-date information.
+  - Easily toggled on/off via the "Web Search" button in the Settings panel.
 
 ## Getting Started
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@tanstack/react-query": "^5.0.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
+    "@pikisoft/duckduckgo-search": "^0.0.4",
     "lucide-react": "^0.294.0",
     "next": "14.0.4",
     "next-themes": "^0.2.1",

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse, NextRequest } from 'next/server';
+import search from '@pikisoft/duckduckgo-search';
+
+interface SearchResultSnippet {
+  text: string;
+  url: string;
+}
+
+export async function POST(originalRequest: NextRequest) {
+  const request = originalRequest.clone();
+  try {
+    const { query, limit = 5 } = await request.json();
+
+    if (!query || typeof query !== 'string' || query.trim() === '') {
+      return NextResponse.json({ error: 'Query parameter is missing or invalid.' }, { status: 400 });
+    }
+
+    console.log(`[API /search] Received query: "${query}"`);
+
+    const searchResultsArray: SearchResultSnippet[] = [];
+
+    try {
+      const asyncGeneratorResults = search.text(query); // search.text() returns an AsyncGenerator
+      // Define the expected structure of results from @pikisoft/duckduckgo-search, using 'href'
+      type PikisoftTextResult = { title: string, body: string, href?: string, icon?: string, hostname?: string }; 
+      const collectedDdGResults: PikisoftTextResult[] = [];
+
+      console.log(`[API /search] Initialized AsyncGenerator for query "${query}". Attempting to collect results...`);
+
+      let itemsCollected = 0;
+      for await (const result of asyncGeneratorResults) {
+        const currentResult = result as PikisoftTextResult; // Type assertion for clarity
+
+        // Ensure essential fields are present, using 'href'
+        if (currentResult && currentResult.body && currentResult.href) { 
+          if (itemsCollected === 0) { // Log only the first item that's about to be collected
+            console.log(`[API /search] Structure of first valid result to be collected:`, currentResult);
+          }
+          collectedDdGResults.push(currentResult);
+          itemsCollected++;
+          if (itemsCollected >= limit) {
+            break; // Stop collecting once we have enough items (respecting the limit)
+          }
+        }
+      }
+
+      console.log(`[API /search] Collected ${collectedDdGResults.length} results from '@pikisoft/duckduckgo-search' for query "${query}".`);
+      // console.log("[API /search] Collected results content:", collectedDdGResults); // Optional: for deeper debugging
+
+      if (collectedDdGResults.length > 0) {
+        for (const item of collectedDdGResults) { 
+          // Ensure item.href is present before pushing (it should be due to the check above)
+          if (item.href) { 
+            searchResultsArray.push({
+              text: item.body,
+              url: item.href // Source from item.href, assign to 'url' in SearchResultSnippet
+            });
+          }
+        }
+      }
+    } catch (searchError: any) {
+      console.error(`[API /search] Error using '@pikisoft/duckduckgo-search' package for query "${query}":`, searchError);
+    }
+
+    console.log(`[API /search] Extracted snippets for query "${query}":`, searchResultsArray);
+
+    return NextResponse.json({ searchResultsArray });
+
+  } catch (error: any) {
+    console.error('[API /search] General error in POST handler:', error);
+    if (error instanceof SyntaxError) {
+      return NextResponse.json({ error: 'Invalid JSON in request body.' }, { status: 400 });
+    }
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/lib/tokenUtils.ts
+++ b/src/lib/tokenUtils.ts
@@ -1,0 +1,34 @@
+export const MODEL_CONTEXT_WINDOWS: { [key: string]: number } = {
+  // Common models - this list should be expanded and kept up-to-date
+  'openai/gpt-4': 8192,
+  'openai/gpt-4-32k': 32768,
+  'openai/gpt-4-turbo': 128000,
+  'openai/gpt-3.5-turbo': 16385, // gpt-3.5-turbo-1106, common one
+  'anthropic/claude-2': 200000, // Claude 2.1 has 200k
+  'anthropic/claude-instant-1': 100000,
+  'google/gemini-pro': 32768, // approximation, includes input and output
+  'mistralai/mistral-7b-instruct': 8000, // Approximation, common context length
+  'default_model_name': 8000 // A sensible default if model not found
+};
+
+/**
+ * Estimates the number of tokens in a string.
+ * A common rough heuristic is 1 token ~ 4 characters for English text.
+ * This is a simplification and may not be accurate for all models or languages.
+ * For more precise token counting, model-specific tokenizers are needed.
+ * @param text The text to estimate tokens for.
+ * @returns An estimated token count.
+ */
+export const estimateTokens = (text: string): number => {
+  if (!text) return 0;
+  return Math.ceil(text.length / 4);
+};
+
+/**
+ * Retrieves the maximum context token limit for a given model.
+ * @param modelName The name of the model.
+ * @returns The maximum token limit, or a default if the model is not found.
+ */
+export const getModelContextLimit = (modelName: string): number => {
+  return MODEL_CONTEXT_WINDOWS[modelName] || MODEL_CONTEXT_WINDOWS['default_model_name'];
+};


### PR DESCRIPTION
Rather than implement tooluse framework, I've implemented web search feature that will work with any model. The web search feature uses a background LLM call using the currently selected model and settings, to take the current user prompt and retrieve a set of search terms from it relevant to the query. These terms are then sent to DuckDuckGo search, results retrieved, and those results are appended to the system prompt at the point of execution of the main prompt in the interface. This means that ANY model - tool use or not, can benefit from web search capabilities without actually having tool calling features. 